### PR TITLE
Fix chat layout panel orders

### DIFF
--- a/ai-productivity-app/frontend/src/components/chat/ChatLayout.jsx
+++ b/ai-productivity-app/frontend/src/components/chat/ChatLayout.jsx
@@ -26,14 +26,14 @@ export default function ChatLayout({
         autoSaveId="chat-layout-main"
       >
         {/* Chat/Content Area */}
-        <Panel defaultSize={showSidebar ? 70 : 100} minSize={50}>
+        <Panel id="content" order={1} defaultSize={showSidebar ? 70 : 100} minSize={50}>
           {showEditor ? (
             // Vertical split for chat + editor
             <PanelGroup
               direction="vertical"
               autoSaveId="chat-editor-vertical"
             >
-              <Panel defaultSize={65} minSize={30}>
+              <Panel id="chat" order={1} defaultSize={65} minSize={30}>
                 {children}
               </Panel>
 
@@ -43,7 +43,7 @@ export default function ChatLayout({
                 </div>
               </PanelResizeHandle>
 
-              <Panel defaultSize={35} minSize={20}>
+              <Panel id="editor" order={2} defaultSize={35} minSize={20}>
                 <div className="h-full relative">
                   {/* Close button for editor */}
                   {onEditorClose && (
@@ -74,6 +74,8 @@ export default function ChatLayout({
             </PanelResizeHandle>
 
             <Panel
+              id="sidebar"
+              order={2}
               defaultSize={30}
               minSize={20}
               maxSize={40}


### PR DESCRIPTION
## Summary
- assign persistent `id` and `order` values for each `<Panel>`

## Testing
- `pytest -q` *(fails: psycopg2 connection and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_685f367602e48328ba50d6995965e3b5

## Summary by Sourcery

Enhancements:
- Add id and order props to content, chat, editor, and sidebar panels for persistent panel ordering and resizing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Added explicit identifiers and ordering to chat, editor, and sidebar panels for improved panel management and clarity. No changes to layout or visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->