### PR TITLE
fix monaco layout resizing

### DIFF
--- a/ai-productivity-app/frontend/src/components/chat/ChatLayout.jsx
+++ b/ai-productivity-app/frontend/src/components/chat/ChatLayout.jsx
@@ -34,7 +34,6 @@ export default function ChatLayout({
             <PanelGroup
               direction="vertical"
               autoSaveId="chat-editor-vertical"
-              onLayout={onLayout}
             >
               <Panel defaultSize={65} minSize={30}>
                 {children}

--- a/ai-productivity-app/frontend/src/components/chat/ChatLayout.jsx
+++ b/ai-productivity-app/frontend/src/components/chat/ChatLayout.jsx
@@ -15,7 +15,8 @@ export default function ChatLayout({
   onSidebarToggle,
   onEditorToggle,
   onSidebarClose,
-  onEditorClose
+  onEditorClose,
+  onLayout
 }) {
   return (
     <div className="flex flex-col h-full bg-gray-50 dark:bg-gray-900">
@@ -24,6 +25,7 @@ export default function ChatLayout({
         direction="horizontal"
         className="flex-1"
         autoSaveId="chat-layout-main"
+        onLayout={onLayout}
       >
         {/* Chat/Content Area */}
         <Panel defaultSize={showSidebar ? 70 : 100} minSize={50}>
@@ -32,6 +34,7 @@ export default function ChatLayout({
             <PanelGroup
               direction="vertical"
               autoSaveId="chat-editor-vertical"
+              onLayout={onLayout}
             >
               <Panel defaultSize={65} minSize={30}>
                 {children}

--- a/ai-productivity-app/frontend/src/components/editor/MonacoRoot.jsx
+++ b/ai-productivity-app/frontend/src/components/editor/MonacoRoot.jsx
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy, useEffect, useRef } from 'react';
+import React, { Suspense, lazy, useEffect, useRef, forwardRef, useImperativeHandle } from 'react';
 import LoadingSpinner from '../common/LoadingSpinner';
 import { useTheme } from '../../hooks/useTheme';
 import useCodeEditor from '../../hooks/useCodeEditor';
@@ -10,7 +10,7 @@ const MonacoEditor = lazy(() => import('@monaco-editor/react'));
  * Monaco Editor wrapper with lazy loading and error boundary
  * This component handles loading states and provides a consistent interface
  */
-const MonacoRoot = ({ 
+const MonacoRoot = forwardRef(({
   value = '',
   defaultValue = '',
   language = 'javascript',
@@ -26,9 +26,14 @@ const MonacoRoot = ({
   filename = null,
   enableCopilot = true,
   ...props 
-}) => {
+}, ref) => {
   const { theme: appTheme } = useTheme();
   const editorRef = useRef(null);
+
+  // Expose imperative API to parent components
+  useImperativeHandle(ref, () => ({
+    layout: () => editorRef.current?.layout(),
+  }));
   
   // Use app theme if no custom theme is provided
   const effectiveTheme = customTheme || (appTheme === 'dark' ? 'vs-dark' : 'vs-light');

--- a/ai-productivity-app/frontend/src/pages/ProjectChatPage.jsx
+++ b/ai-productivity-app/frontend/src/pages/ProjectChatPage.jsx
@@ -333,9 +333,13 @@ export default function ProjectChatPage() {
     scrollToBottom();
   }, [messages, streamingMessages, scrollToBottom]);
 
-  // Re-layout Monaco editor when its container size changes
+  // Debounced re-layout of Monaco editor when its container size changes and editor is visible
   useEffect(() => {
-    monacoRef.current?.layout();
+    if (!showMonacoEditor) return;
+    const handler = setTimeout(() => {
+      monacoRef.current?.layout();
+    }, 150); // 150ms debounce, adjust as needed
+    return () => clearTimeout(handler);
   }, [showMonacoEditor, panelSizes]);
 
   // ---------------------------------------------------------------------------

--- a/ai-productivity-app/frontend/src/pages/ProjectChatPage.jsx
+++ b/ai-productivity-app/frontend/src/pages/ProjectChatPage.jsx
@@ -135,6 +135,10 @@ export default function ProjectChatPage() {
   const [editorLanguage, setEditorLanguage] = useState('python');
   const [currentFile, setCurrentFile] = useState();
 
+  // Ref to access Monaco editor imperatively
+  const monacoRef = useRef(null);
+  const [panelSizes, setPanelSizes] = useState([]);
+
   // Refs for auto-scroll
   const messagesEndRef = useRef(null);
   const messageListRef = useRef(null);
@@ -329,6 +333,11 @@ export default function ProjectChatPage() {
     scrollToBottom();
   }, [messages, streamingMessages, scrollToBottom]);
 
+  // Re-layout Monaco editor when its container size changes
+  useEffect(() => {
+    monacoRef.current?.layout();
+  }, [showMonacoEditor, panelSizes]);
+
   // ---------------------------------------------------------------------------
   // Render helpers
   // ---------------------------------------------------------------------------
@@ -519,6 +528,7 @@ export default function ProjectChatPage() {
         showEditor={showMonacoEditor}
         onSidebarClose={() => setShowKnowledgeAssistant(false)}
         onEditorClose={() => setShowMonacoEditor(false)}
+        onLayout={setPanelSizes}
         sidebar={
           <KnowledgeAssistant
             projectId={projectId}
@@ -533,6 +543,7 @@ export default function ProjectChatPage() {
               <h3 className="text-lg font-semibold">Code Editor</h3>
             </div>
             <MonacoRoot
+              ref={monacoRef}
               value={editorContent}
               onChange={setEditorContent}
               language={editorLanguage}


### PR DESCRIPTION
## Summary
- expose layout via `useImperativeHandle` in `MonacoRoot`
- bubble `onLayout` from `ChatLayout` panels
- trigger editor `layout()` in `ProjectChatPage` when panels resize or toggle

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685f4a54bac48328b5fc9ba7d48984a3

## Summary by Sourcery

Fix Monaco editor resizing by exposing its layout API, propagating panel layout events, and re-triggering the editor’s layout on panel size changes.

New Features:
- Expose the Monaco editor’s layout method via an imperative handle in MonacoRoot.

Bug Fixes:
- Ensure Monaco editor layout updates correctly when panels resize or toggle.

Enhancements:
- Bubble onLayout events from ChatLayout panels.
- Track panel sizes in ProjectChatPage and invoke editor.layout() when those sizes change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved chat and editor panel resizing: The layout now updates dynamically, ensuring the editor resizes correctly when panels are adjusted.
  * Enhanced editor experience: The editor automatically re-layouts when shown or when panel sizes change, providing a smoother user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->