### PR TITLE
Fix editor panel layout restore

### DIFF
--- a/ai-productivity-app/frontend/src/components/chat/ChatLayout.jsx
+++ b/ai-productivity-app/frontend/src/components/chat/ChatLayout.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { Brain, X } from 'lucide-react';
 
@@ -17,6 +17,30 @@ export default function ChatLayout({
   onSidebarClose,
   onEditorClose
 }) {
+  const editorGroupRef = useRef(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const storageKey = 'react-resizable-panels:chat-editor-vertical';
+
+    if (showEditor) {
+      const saved = localStorage.getItem(storageKey);
+      if (saved) {
+        try {
+          const parsed = JSON.parse(saved);
+          const entry = Object.values(parsed)[0];
+          if (entry && Array.isArray(entry.layout) && entry.layout[1] === 0) {
+            editorGroupRef.current?.setLayout([65, 35]);
+          }
+        } catch {
+          // ignore parse errors
+        }
+      }
+    } else {
+      localStorage.removeItem(storageKey);
+    }
+  }, [showEditor]);
   return (
     <div className="flex flex-col h-full bg-gray-50 dark:bg-gray-900">
       {/* Main horizontal layout */}
@@ -32,6 +56,7 @@ export default function ChatLayout({
             <PanelGroup
               direction="vertical"
               autoSaveId="chat-editor-vertical"
+              ref={editorGroupRef}
             >
               <Panel defaultSize={65} minSize={30}>
                 {children}

--- a/ai-productivity-app/frontend/src/components/chat/ChatLayout.jsx
+++ b/ai-productivity-app/frontend/src/components/chat/ChatLayout.jsx
@@ -29,11 +29,14 @@ export default function ChatLayout({
       if (saved) {
         try {
           const parsed = JSON.parse(saved);
-          const entry = Object.values(parsed)[0];
-          if (entry && Array.isArray(entry.layout) && entry.layout[1] === 0) {
-            editorGroupRef.current?.setLayout([65, 35]);
+          // Look for the correct entry by matching the autoSaveId
+          const entry = parsed['chat-editor-vertical'];
+          if (entry && Array.isArray(entry.layout) && entry.layout.length >= 2 && entry.layout[1] === 0) {
+            const DEFAULT_LAYOUT = [65, 35];
+            editorGroupRef.current?.setLayout(DEFAULT_LAYOUT);
           }
-        } catch {
+        } catch (error) {
+          console.warn('Failed to parse panel layout from localStorage:', error);
           // ignore parse errors
         }
       }


### PR DESCRIPTION
## Summary
- reset editor panel height if saved layout collapses it
- clear saved layout when editor closes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685f5cc4a9cc83288a334a8b1e92e026

## Summary by Sourcery

Ensure the editor panel layout is correctly restored by resetting collapsed panels and clearing saved layouts on close

Bug Fixes:
- Reset editor panel height to default if the restored layout collapses it
- Remove saved editor layout from localStorage when the editor is closed to prevent persisting a collapsed state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the behavior of the chat and editor panel layout so that the editor panel is no longer restored in a fully collapsed state when toggled visible.
  * Enhanced panel size restoration for a smoother user experience when showing or hiding the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->