### PR TITLE
Fix KnowledgeAssistant overlay height with dvh fallback

### DIFF
--- a/ai-productivity-app/frontend/src/components/chat/KnowledgeAssistant.jsx
+++ b/ai-productivity-app/frontend/src/components/chat/KnowledgeAssistant.jsx
@@ -158,7 +158,7 @@ export default function KnowledgeAssistant({
 
   // Determine container styles based on mode
   const containerClass = containerMode === 'overlay'
-    ? `fixed ${position === 'right' ? 'right-2 sm:right-4' : 'left-2 sm:left-4'} top-20 w-80 sm:w-96 z-50 max-h-[calc(100vh-6rem)]`
+    ? `fixed ${position === 'right' ? 'right-2 sm:right-4' : 'left-2 sm:left-4'} top-20 w-80 sm:w-96 z-50 max-h-[calc(var(--dvh)-6rem)]`
     : 'w-full h-full flex flex-col';
 
   const panelClass = containerMode === 'overlay'

--- a/ai-productivity-app/frontend/src/styles/globals.css
+++ b/ai-productivity-app/frontend/src/styles/globals.css
@@ -193,6 +193,14 @@
     --success: theme(--color-success);
     --warning: theme(--color-warning);
     --error: theme(--color-error);
+    /* Fallback for dynamic viewport height */
+    --dvh: 100vh;
+  }
+
+  @supports (height: 100dvh) {
+    :root {
+      --dvh: 100dvh;
+    }
   }
 
   * {


### PR DESCRIPTION
## Summary
- ensure KnowledgeAssistant overlay respects dynamic viewport height
- add CSS variable `--dvh` with a `100vh` fallback for browsers lacking `dvh`

## Testing
- `npm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_685f5ccf966c8328bf606480ec3ceb63

## Summary by Sourcery

Ensure the KnowledgeAssistant overlay height adapts to dynamic viewport changes by using a CSS variable for viewport height and applying it to the overlay’s max-height.

Bug Fixes:
- Fix KnowledgeAssistant overlay height on mobile by replacing static 100vh with a dynamic viewport-height calculation.

Enhancements:
- Introduce a --dvh CSS variable with a 100vh fallback and override it to 100dvh when supported.