### PR TITLE
Handle Monaco resize in ChatLayout

### DIFF
--- a/ai-productivity-app/frontend/src/components/chat/ChatLayout.jsx
+++ b/ai-productivity-app/frontend/src/components/chat/ChatLayout.jsx
@@ -15,7 +15,8 @@ export default function ChatLayout({
   onSidebarToggle,
   onEditorToggle,
   onSidebarClose,
-  onEditorClose
+  onEditorClose,
+  monacoRef
 }) {
   return (
     <div className="flex flex-col h-full bg-gray-50 dark:bg-gray-900">
@@ -43,7 +44,13 @@ export default function ChatLayout({
                 </div>
               </PanelResizeHandle>
 
-              <Panel defaultSize={35} minSize={20}>
+              <Panel
+                defaultSize={35}
+                minSize={20}
+                onResize={(size) => {
+                  if (monacoRef?.current) monacoRef.current.layout();
+                }}
+              >
                 <div className="h-full relative">
                   {/* Close button for editor */}
                   {onEditorClose && (

--- a/ai-productivity-app/frontend/src/pages/ProjectChatPage.jsx
+++ b/ai-productivity-app/frontend/src/pages/ProjectChatPage.jsx
@@ -138,6 +138,7 @@ export default function ProjectChatPage() {
   // Refs for auto-scroll
   const messagesEndRef = useRef(null);
   const messageListRef = useRef(null);
+  const monacoRef = useRef(null);
 
   // -------------------------------------------------------------
   // Knowledge-assistant helpers – must run every render to keep
@@ -519,6 +520,7 @@ export default function ProjectChatPage() {
         showEditor={showMonacoEditor}
         onSidebarClose={() => setShowKnowledgeAssistant(false)}
         onEditorClose={() => setShowMonacoEditor(false)}
+        monacoRef={monacoRef}
         sidebar={
           <KnowledgeAssistant
             projectId={projectId}
@@ -535,6 +537,9 @@ export default function ProjectChatPage() {
             <MonacoRoot
               value={editorContent}
               onChange={setEditorContent}
+              onMount={(editor) => {
+                monacoRef.current = editor;
+              }}
               language={editorLanguage}
               height="100%"
               className="min-h-[200px]"


### PR DESCRIPTION
## Summary
- expose `monacoRef` prop in `ChatLayout`
- trigger Monaco editor layout on panel resize
- wire `monacoRef` up in `ProjectChatPage`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run test:run` in `frontend` *(fails: vitest not found)*
- `pytest test_create_session.py` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_685f5d5eb98883288000cd1ee1dd3729

## Summary by Sourcery

Expose a Monaco editor reference to enable automatic layout updates when resizing the chat editor panel

Enhancements:
- Expose monacoRef prop in ChatLayout
- Invoke monacoRef.current.layout() on panel resize
- Create and pass monacoRef in ProjectChatPage and initialize it on Monaco editor mount

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Monaco editor responsiveness by ensuring it automatically updates its layout when the editor panel is resized.
  * Enhanced integration of the Monaco editor, allowing external components to access the editor instance for better extensibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->